### PR TITLE
Improve whitelist data handling and add status command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+CodeUtils/__pycache__/
+*.pyc

--- a/CodeUtils/embeds.py
+++ b/CodeUtils/embeds.py
@@ -1,7 +1,8 @@
-import discord
-from discord.ext import commands
-from datetime import datetime
 import json
+from datetime import datetime
+from typing import Optional
+
+import discord
 
 server_ip = None
 server_rcon_port = None
@@ -74,5 +75,28 @@ def ConfigChanged():
     config_reload()
     embed = discord.Embed(title=embed_title, color=discord.Color.green(),
                           description="The Config was saved")
+    embed.set_footer(text=f"created by {bot_name} | {datetime.now().strftime('%d/%m/%y %H:%M:%S')}")
+    return embed
+
+
+def MCStatusEmbed(minecraft_name: Optional[str], allowed: bool):
+    config_reload()
+
+    if minecraft_name:
+        description = (
+            "Dein Discord-Account ist aktuell mit dem Minecraft-Namen "
+            f"`{minecraft_name}` verknüpft."
+        )
+        color = discord.Color.green()
+    else:
+        description = (
+            "Für deinen Discord-Account ist noch kein Minecraft-Name hinterlegt. "
+            "Nutze `/mc-setname`, um dich auf die Whitelist setzen zu lassen."
+        )
+        color = discord.Color.orange()
+
+    embed = discord.Embed(title=embed_title, color=color, description=description)
+    status_text = "aktiv" if allowed else "inaktiv"
+    embed.add_field(name="Whitelist-Zugriff", value=f"`{status_text}`", inline=False)
     embed.set_footer(text=f"created by {bot_name} | {datetime.now().strftime('%d/%m/%y %H:%M:%S')}")
     return embed

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,39 @@
+"""Utility helpers for reading and writing persistent user data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_PATH = BASE_DIR / "user_data.json"
+
+
+def load_user_data() -> Dict[str, Any]:
+    """Return the persisted user data as a dictionary.
+
+    The data file is created automatically the first time this function is
+    called so that other modules can rely on its existence.
+    """
+
+    if not DATA_PATH.exists():
+        save_user_data({})
+        return {}
+
+    with DATA_PATH.open("r", encoding="utf-8") as file:
+        try:
+            return json.load(file)
+        except json.JSONDecodeError:
+            # If the file somehow becomes corrupted we start with a clean slate
+            # to avoid crashing the bot and blocking whitelist updates.
+            save_user_data({})
+            return {}
+
+
+def save_user_data(data: Dict[str, Any]) -> None:
+    """Persist the provided user data to disk."""
+
+    with DATA_PATH.open("w", encoding="utf-8") as file:
+        json.dump(data, file, indent=4)
+

--- a/mccommands.py
+++ b/mccommands.py
@@ -1,11 +1,16 @@
 import datetime
-import setup
-import discord
-from discord.ext import commands
-from discord import  app_commands
-from CodeUtils import embeds
 import json
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from CodeUtils import embeds
 import mcrcon
+import setup
+
+from data_store import load_user_data, save_user_data
 
 bot_owner_id = None
 server_ip = None
@@ -14,16 +19,23 @@ server_rcon_password = None
 server_member_role_name = None
 bot_name = None
 
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
 def config_reload():
     global server_ip, server_rcon_port, server_rcon_password, server_member_role_name, bot_name, bot_owner_id
     with open('config.json', 'r') as config:
         config = json.load(config)
-    bot_owner_id = int(config["bot_owner_id"])
-    server_ip = config["server_ip"]
-    server_rcon_port = config["server_rcon_port"]
-    server_rcon_password = config["server_rcon_password"]
-    server_member_role_name = config["server_member_role_name"]
-    bot_name = config["bot_name"]
+    bot_owner_id = _to_int(config.get("bot_owner_id"), 0)
+    server_ip = config.get("server_ip", "")
+    server_rcon_port = _to_int(config.get("server_rcon_port"), 25575)
+    server_rcon_password = config.get("server_rcon_password", "")
+    server_member_role_name = config.get("server_member_role_name", "")
+    bot_name = config.get("bot_name", "")
 
 class mccommands(commands.Cog):
     def __init__(self,bot):
@@ -34,7 +46,7 @@ class mccommands(commands.Cog):
     async def mcsetname(self, interaction: discord.Interaction, mcname: str):
         config_reload()
         try:
-            discord_name = str(interaction.user.name)
+            discord_name = str(interaction.user)
             if is_mcname_permission_allowed(discord_name):
                 await check_json(discord_name)
                 await save_to_json(discord_name, mcname)
@@ -52,58 +64,76 @@ class mccommands(commands.Cog):
     async def mchelp(self, interaction: discord.Interaction):
         await interaction.response.send_message(embed=embeds.Help(), view = HelpView())
 
+    @app_commands.command(name="mc-status", description="Shows the Minecraft name linked to your Discord account.")
+    async def mcstatus(self, interaction: discord.Interaction):
+        discord_name = str(interaction.user)
+        data = load_user_data()
+        record = data.get(discord_name, {})
+        minecraft_name = record.get("minecraft_name")
+        allowed = record.get("permission", False)
+
+        await interaction.response.send_message(
+            embed=embeds.MCStatusEmbed(minecraft_name, allowed),
+            ephemeral=True,
+        )
+
 async def check_json(discord_name):
     config_reload()
-    data = {}
-    try:
-        with open('user_data.json', 'r') as file:
-            data = json.load(file)
-    except FileNotFoundError:
-        pass
+    data = load_user_data()
+    record = data.get(discord_name)
 
-    minecraft_name = data[discord_name]["minecraft_name"]
+    if not record:
+        return
+
+    minecraft_name = record.get("minecraft_name", "")
     if minecraft_name != "":
         print(f"|🔍|{datetime.datetime.now().strftime('%d/%m/%y %H:%M:%S')}| - Checked Json File and deleted the old {minecraft_name} from the whitelist")
         rcon = mcrcon.MCRcon(host=str(server_ip), password=str(server_rcon_password), port=int(server_rcon_port))
-        rcon.connect()
-        rcon.command(f'whitelist remove {minecraft_name}')
-        rcon.command(f'kick {minecraft_name} Du bist nicht mehr auf der Whitelist!')
-        rcon.disconnect()
+        try:
+            rcon.connect()
+            rcon.command(f'whitelist remove {minecraft_name}')
+            rcon.command(f'kick {minecraft_name} Du bist nicht mehr auf der Whitelist!')
+        finally:
+            try:
+                rcon.disconnect()
+            except Exception:
+                pass
+        record["minecraft_name"] = ""
+        data[discord_name] = record
+        save_user_data(data)
     else:
         print(f"|🔍|{datetime.datetime.now().strftime('%d/%m/%y %H:%M:%S')}| - Checked Json File and no old user name was found")
 
 
 
 async def save_to_json(discord_name, minecraft_name):
-    data = {}
-    try:
-        with open('user_data.json', 'r') as file:
-            data = json.load(file)
-    except FileNotFoundError:
-        pass
-
-    data[discord_name] = {"minecraft_name": minecraft_name, "permission": True}
-
-    with open('user_data.json', 'w') as file:
-        json.dump(data, file, indent=4)
+    data = load_user_data()
+    record = data.get(discord_name, {"minecraft_name": "", "permission": True})
+    record["minecraft_name"] = minecraft_name
+    record["permission"] = True
+    data[discord_name] = record
+    save_user_data(data)
 
 
 async def add_to_whitelist(discord_name, minecraft_name):
     config_reload()
     rcon = mcrcon.MCRcon(host=str(server_ip), password=str(server_rcon_password), port=int(server_rcon_port))
-    rcon.connect()
-    rcon.command(f'whitelist add {minecraft_name}')
-    rcon.disconnect()
+    try:
+        rcon.connect()
+        rcon.command(f'whitelist add {minecraft_name}')
+    finally:
+        try:
+            rcon.disconnect()
+        except Exception:
+            pass
 
 
 
 def is_mcname_permission_allowed(member):
-    with open('user_data.json', 'r') as file:
-        data = json.load(file)
+    data = load_user_data()
 
-    discord_name = str(member)
-    if discord_name in data:
-        return data[discord_name]["permission"]
+    if member in data:
+        return data[member].get("permission", False)
 
     return False
 

--- a/setup.py
+++ b/setup.py
@@ -1,66 +1,130 @@
-from CodeUtils import embeds
-import json, discord, datetime
+import json
+from typing import Any
+
+import discord
+from discord import app_commands
 from discord.ext import commands
-from discord import  app_commands
 
-bot_owner_id = None
-server_ip = None
-server_rcon_port = None
-server_rcon_password = None
-server_member_role_name = None
-embed_title = None
-server_port = None
+from CodeUtils import embeds
 
+bot_owner_id = 0
+server_ip = ""
+server_rcon_port = 25575
+server_rcon_password = ""
+server_member_role_name = ""
+embed_title = ""
+server_port = 25565
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def config_reload():
-    global server_ip, server_rcon_port, server_rcon_password, server_member_role_name, embed_title, server_port, bot_owner_id
-    with open('config.json', 'r') as config:
-        config = json.load(config)
-    bot_owner_id = int(config["bot_owner_id"])
-    server_ip = str(config["server_ip"])
-    server_rcon_port = int(config["server_rcon_port"])
-    server_rcon_password = str(config["server_rcon_password"])
-    server_member_role_name = config["server_member_role_name"]
-    embed_title = config["embed_title"]
-    server_port = str(config["server_port"])
+    global server_ip, server_rcon_port, server_rcon_password
+    global server_member_role_name, embed_title, server_port, bot_owner_id
+
+    with open('config.json', 'r', encoding='utf-8') as config_file:
+        config = json.load(config_file)
+
+    bot_owner_id = _to_int(config.get("bot_owner_id"), 0)
+    server_ip = str(config.get("server_ip", ""))
+    server_rcon_port = _to_int(config.get("server_rcon_port"), 25575)
+    server_rcon_password = str(config.get("server_rcon_password", ""))
+    server_member_role_name = str(config.get("server_member_role_name", ""))
+    embed_title = str(config.get("embed_title", ""))
+    server_port = _to_int(config.get("server_port"), 25565)
 
 
 class setup(commands.Cog):
-    def __init__(self,bot):
+    def __init__(self, bot):
         self.bot = bot
-    config_reload()
+        config_reload()
 
-    @app_commands.command(name="mc-setup",description="this command lets you configure the bot")
+    @app_commands.command(name="mc-setup", description="this command lets you configure the bot")
     async def mcsetup(self, interaction: discord.Interaction):
         config_reload()
         if interaction.user.id == bot_owner_id:
             await interaction.response.send_modal(SetupModal())
         else:
-            await interaction.response.send_message(embed=embeds.NotOwner())
+            await interaction.response.send_message(embed=embeds.NotOwner(), ephemeral=True)
+
 
 class SetupModal(discord.ui.Modal):
     def __init__(self):
+        config_reload()
         super().__init__(title="Config")
 
-    new_server_ip = discord.ui.TextInput(label="server_ip", default=str(server_ip), style=discord.TextStyle.short, placeholder="mc.yourdomain.de")
-    new_server_rcon_port = discord.ui.TextInput(label="server_rcon_port", default=str(server_rcon_port), style=discord.TextStyle.short, placeholder="default: 25575")
-    new_server_rcon_password = discord.ui.TextInput(label="server_rcon_password", default=str(server_rcon_password), style=discord.TextStyle.short, placeholder="Password")
-    new_server_member_role_name = discord.ui.TextInput(label="server_member_role_name", default=str(server_member_role_name), style=discord.TextStyle.short, placeholder= "MC-Member")
-    new_server_port = discord.ui.TextInput(label="server_port", default=str(server_port), style=discord.TextStyle.short, placeholder="default: 25565")
+        self.new_server_ip = discord.ui.TextInput(
+            label="server_ip",
+            default=str(server_ip),
+            style=discord.TextStyle.short,
+            placeholder="mc.yourdomain.de",
+        )
+        self.new_server_rcon_port = discord.ui.TextInput(
+            label="server_rcon_port",
+            default=str(server_rcon_port),
+            style=discord.TextStyle.short,
+            placeholder="default: 25575",
+        )
+        self.new_server_rcon_password = discord.ui.TextInput(
+            label="server_rcon_password",
+            default=str(server_rcon_password),
+            style=discord.TextStyle.short,
+            placeholder="Password",
+        )
+        self.new_server_member_role_name = discord.ui.TextInput(
+            label="server_member_role_name",
+            default=str(server_member_role_name),
+            style=discord.TextStyle.short,
+            placeholder="MC-Member",
+        )
+        self.new_server_port = discord.ui.TextInput(
+            label="server_port",
+            default=str(server_port),
+            style=discord.TextStyle.short,
+            placeholder="default: 25565",
+        )
 
+        for input_field in (
+            self.new_server_ip,
+            self.new_server_rcon_port,
+            self.new_server_rcon_password,
+            self.new_server_member_role_name,
+            self.new_server_port,
+        ):
+            self.add_item(input_field)
 
     async def on_submit(self, interaction: discord.Interaction):
-        with open('config.json', 'r') as config:
-            config = json.load(config)
+        try:
+            new_rcon_port = int(self.new_server_rcon_port.value)
+            new_server_port = int(self.new_server_port.value)
+        except ValueError:
+            await interaction.response.send_message(
+                "Bitte gib gültige Zahlen für die Ports ein.",
+                ephemeral=True,
+            )
+            return
 
-        config["server_ip"] = self.new_server_ip
-        config["server_rcon_port"] = int(self.new_server_rcon_port)
-        config["server_rcon_password"] = self.new_server_rcon_password
-        config["server_member_role_name"] = self.new_server_member_role_name
-        config["server_port"] = int(self.new_server_port)
+        with open('config.json', 'r', encoding='utf-8') as config_file:
+            config = json.load(config_file)
 
-        with open('config.json.json', 'w') as file:
+        config.update(
+            {
+                "server_ip": self.new_server_ip.value.strip(),
+                "server_rcon_port": new_rcon_port,
+                "server_rcon_password": self.new_server_rcon_password.value.strip(),
+                "server_member_role_name": self.new_server_member_role_name.value.strip(),
+                "server_port": new_server_port,
+            }
+        )
+
+        with open('config.json', 'w', encoding='utf-8') as file:
             json.dump(config, file, indent=4)
 
-        await interaction.response.send_message(embed= embeds.ConfigChanged())
+        config_reload()
+        await interaction.response.send_message(embed=embeds.ConfigChanged(), ephemeral=True)
+


### PR DESCRIPTION
## Summary
- centralize whitelist persistence and make role updates resilient to missing or corrupt data
- fix the interactive setup modal so configuration changes are validated and saved correctly
- add an `/mc-status` slash command and embed messaging to show a member’s current whitelist status

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68daf743ad08832f8cc7c762e2d3520b